### PR TITLE
Allow geolocator 9.0.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
     sdk: flutter
   flutter_compass: ^0.7.0
   flutter_map: ^1.1.0
-  geolocator: ^8.2.1
+  geolocator: ^8.2.1|^9.0.0
   latlong2: ^0.8.1
 
 dev_dependencies:


### PR DESCRIPTION
A new geolocator 9.0.0 has just released, but  dependent version is set to ^8.2.1 which prevent using the latest version of geolocator.

This PR adds support for v9.0.0, while still keeping support for 8.2.1. Hopefully this can be included in the next release