### PR TITLE
error when checking if widget is mounted inside _subscriptHeadingStream

### DIFF
--- a/lib/src/widgets/current_location_layer.dart
+++ b/lib/src/widgets/current_location_layer.dart
@@ -440,7 +440,7 @@ class _CurrentLocationLayerState extends State<CurrentLocationLayer>
   void _subscriptHeadingStream() {
     _headingStreamSubscription = widget.headingStream.listen(
       (heading) {
-        if (!context.mounted) {
+        if (!mounted) {
           return;
         }
         if (heading == null) {


### PR DESCRIPTION
Found that on iOS devices this causes consitent error when you switch between map and other screens. Error is the following:

```
[ERROR:flutter/runtime/dart_vm_initializer.cc(41)] Unhandled Exception: This widget has been unmounted, so the State no longer has a context (and should be considered defunct).
Consider canceling any active work during "dispose" or using the "mounted" getter to determine if the State is still active.
#0      State.context.<anonymous closure> (package:flutter/src/widgets/framework.dart:951:9)
#1      State.context (package:flutter/src/widgets/framework.dart:957:6)
#2      TickerProviderStateMixin._updateTickerModeNotifier (package:flutter/src/widgets/ticker_provider.dart:328:70)
#3      TickerProviderStateMixin.createTicker (package:flutter/src/widgets/ticker_provider.dart:292:7)
#4      new AnimationController (package:flutter/src/animation/animation_controller.dart:247:21)
#5      _CurrentLocationLayerState._rotateMarker (package:flutter_map_location_marker/src/widgets/current_location_layer.dart:619:40)
#6      _CurrentLocationLayerState._subscriptHeadingStream.<anonymous closure> (package:flutter_map_location_marker/src/widgets/current_location_layer.dart:456:13)
#7      _RootZone.runUnaryGuarded (dart:async/zone.dart:1594:10)
#8      _BufferingStreamSubscription._sendData (dart:async/stream_impl.dart:339:11)
#9      _BufferingStreamSubscription._add (dart:async/stream_impl.dart:271:7)
#10     _ForwardingStreamSubscription._add (dart:async/stream_pipe.dart:123:11)
#11     _MapStream._handleData (dart:async/stream_pipe.dart:218:10)
#12     _ForwardingStreamSubscription._handleData (dart:async/stream_pipe.dart:153:13)
#13     _RootZone.runUnaryGuarded (dart:async/zone.dart:1594:10)
#14     _BufferingStreamSubscription._sendData (dart:async/stream_impl.dart:339:11)
#15     _BufferingStreamSubscription._add (dart:async/stream_impl.dart:271:7)
#16     _ForwardingStreamSubscription._add (dart:async/stream_pipe.dart:123:11)
#17     _WhereStream._handleData (dart:async/stream_pipe.dart:195:12)
#18     _ForwardingStreamSubscription._handleData (dart:async/stream_pipe.dart:153:13)
#19     _RootZone.runUnaryGuarded (dart:async/zone.dart:1594:10)
#20     _BufferingStreamSubscription._sendData (dart:async/stream_impl.dart:339:11)
#21     _BufferingStreamSubscription._add (dart:async/stream_impl.dart:271:7)
#22     _ForwardingStreamSubscription._add (dart:async/stream_pipe.dart:123:11)
#23     _MapStream._handleData (dart:async/stream_pipe.dart:218:10)
#24     _ForwardingStreamSubscription._handleData (dart:async/stream_pipe.dart:153:13)
#25     _RootZone.runUnaryGuarded (dart:async/zone.dart:1594:10)
#26     _BufferingStreamSubscription._sendData (dart:async/stream_impl.dart:339:11)
#27     _DelayedData.perform (dart:async/stream_impl.dart:515:14)
#28     _PendingEvents.handleNext (dart:async/stream_impl.dart:620:11)
#29     _PendingEvents.schedule.<anonymous closure> (dart:async/stream_impl.dart:591:7)
#30     _microtaskLoop (dart:async/schedule_microtask.dart:40:21)
#31     _startMicrotaskLoop (dart:async/schedule_microtask.dart:49:5)
```

Instead of asking for condition "!context.mounted", it is enough to use mounted getter and then the error disappears. Believe this is what people are reffering to in issue #96.