### PR TITLE
Added alignment property

### DIFF
--- a/lib/src/options/style.dart
+++ b/lib/src/options/style.dart
@@ -33,6 +33,16 @@ class LocationMarkerStyle {
   /// The color of the heading sector. Default to ARGB(0xCC2196F3).
   final Color headingSectorColor;
 
+  /// Alignment of the marker relative to the normal center at the marker location
+  ///
+  /// For example, [Alignment.topCenter] will mean the entire marker widget is
+  /// located above the markker location.
+  ///
+  /// The center of rotation (anchor) will be opposite this.
+  ///
+  /// Defaults to [Alignment.center] if also unset.
+  final Alignment markerAlignment;
+
   /// Create a LocationMarkerStyle.
   const LocationMarkerStyle({
     this.marker = const DefaultLocationMarker(),
@@ -43,5 +53,6 @@ class LocationMarkerStyle {
     this.showHeadingSector = true,
     this.headingSectorRadius = 60,
     this.headingSectorColor = const Color(0xCC2196F3),
+    this.markerAlignment = Alignment.center,
   });
 }

--- a/lib/src/widgets/location_marker_layer.dart
+++ b/lib/src/widgets/location_marker_layer.dart
@@ -66,6 +66,7 @@ class LocationMarkerLayer extends StatelessWidget {
               point: position.latLng,
               width: style.markerSize.width,
               height: style.markerSize.height,
+              alignment: style.markerAlignment,
               child: switch (style.markerDirection) {
                 MarkerDirection.north => style.marker,
                 MarkerDirection.top => Transform.rotate(


### PR DESCRIPTION
Adding the alignment property to LocationMarkerStyle to set the alignment property on the [Marker class](https://pub.dev/documentation/flutter_map/latest/flutter_map/Marker-class.html) of flutter_map:
https://pub.dev/documentation/flutter_map/latest/flutter_map/Marker/alignment.html

> Alignment of the marker relative to the normal center at [point](https://pub.dev/documentation/flutter_map/latest/flutter_map/Marker/point.html)
> For example, [Alignment.topCenter](https://api.flutter.dev/flutter/painting/Alignment/topCenter-constant.html) will mean the entire marker widget is located above the [point](https://pub.dev/documentation/flutter_map/latest/flutter_map/Marker/point.html).
> 
> The center of rotation (anchor) will be opposite this.
> 
> Defaults to [Alignment.center](https://api.flutter.dev/flutter/painting/Alignment/center-constant.html) if also unset by [MarkerLayer](https://pub.dev/documentation/flutter_map/latest/flutter_map/MarkerLayer-class.html).