### PR TITLE
Update pubspec.yaml to agp update problems

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,9 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_compass: ^0.8.0
+  flutter_compass:
+    git:
+      url: https://github.com/SalihCanBinboga/flutter_compass
   flutter_map: ^7.0.0
   geolocator: ^13.0.1
   latlong2: ^0.9.1


### PR DESCRIPTION
AGP >= 8 need to specify a namespace (https://github.com/hemanthrajv/flutter_compass/issues/104)
We need to update the compileSdk version due to this error "resource android:attr/lStar not found" since Android 12 so update to support 14 and lower (https://github.com/hemanthrajv/flutter_compass/issues/112)

ref: https://github.com/hemanthrajv/flutter_compass/pull/113