### PR TITLE
fix jagged sector rendering on iOS by explicitly defining RadialGradient stops

### DIFF
--- a/lib/src/drawings/heading_sector.dart
+++ b/lib/src/drawings/heading_sector.dart
@@ -43,6 +43,7 @@ class HeadingSector extends CustomPainter {
             color.withValues(alpha: color.a * 0.1),
             color.withValues(alpha: color.a * 0.0),
           ],
+          stops: const [0.0, 0.25, 0.5, 0.75, 1.0],
         ).createShader(rect),
     );
   }


### PR DESCRIPTION
This PR fixes [#151](https://github.com/tlserver/flutter_map_location_marker/issues/151) by explicitly defining the stops parameter in the RadialGradient used in HeadingSector. Previously, the gradient relied on default stops, which caused stripes around the center of the sector on iOS. By specifying the stops [0.0, 0.25, 0.5, 0.75, 1.0], the sector now renders smoothly across both iOS and Android devices.