### PR TITLE
fix: Make `HeadingSector` look smooth on iOS too

### DIFF
--- a/lib/src/drawings/heading_sector.dart
+++ b/lib/src/drawings/heading_sector.dart
@@ -25,15 +25,20 @@ class HeadingSector extends CustomPainter {
   @override
   void paint(Canvas canvas, Size size) {
     final radius = size.shortestSide / 2;
-    final rect = Rect.fromCircle(
-      center: Offset(radius, radius),
-      radius: radius,
-    );
-    canvas.drawArc(
-      rect,
-      pi * 3 / 2 + heading - accuracy,
-      accuracy * 2,
-      true,
+    final center = Offset(radius, radius);
+    final rect = Rect.fromCircle(center: center, radius: radius);
+
+    final startAngle = pi * 3 / 2 + heading - accuracy;
+    final sweepAngle = accuracy * 2;
+
+    final path =
+        Path()
+          ..moveTo(center.dx, center.dy)
+          ..arcTo(rect, startAngle, sweepAngle, false)
+          ..close();
+
+    canvas.drawPath(
+      path,
       Paint()
         ..shader = RadialGradient(
           colors: [


### PR DESCRIPTION
This PR fixes #151. I closed my previous PR on this fix because I couldn't test it thoroughly.
Now that I've been able to test it thoroughly, I can say with certainty that it does indeed solve the problem. ✅

Feel free to merge anytime.